### PR TITLE
change BUILD_MANGO_BENCHER value for download client

### DIFF
--- a/generate-exec-dependency.sh
+++ b/generate-exec-dependency.sh
@@ -8,7 +8,7 @@ echo 'cp ~/mango_bencher-dos-test/start-dos-test.sh .' >> exec-start-template.sh
 
 
 echo ----- stage: create exec-start-build-dependency-build.sh ------
-# the only difference is $DOWNLOAD_MANGO_BENCHER
+# the only difference is $BUILD_MANGO_BENCHER
 [[ ! "$CHANNEL" ]]&& CHANNEL=edge
 cat exec-start-template.sh > exec-start-build-dependency-build.sh
 echo "export CHANNEL=$CHANNEL" >> exec-start-build-dependency-build.sh
@@ -27,11 +27,11 @@ echo 'exec  ./start-build-dependency.sh > start-build-dependency.log' >> exec-st
 chmod +x exec-start-build-dependency-build.sh
 
 echo ----- stage: create exec-start-build-dependency-download.sh ------
-# the only difference is $DOWNLOAD_MANGO_BENCHER
+# the only difference is $BUILD_MANGO_BENCHER
 [[ ! "$CHANNEL" ]]&& CHANNEL=edge
 cat exec-start-template.sh > exec-start-build-dependency-download.sh
 echo "export CHANNEL=$CHANNEL" >> exec-start-build-dependency-download.sh
-echo "export BUILD_MANGO_BENCHER=true" >> exec-start-build-dependency-download.sh
+echo "export BUILD_MANGO_BENCHER=false" >> exec-start-build-dependency-download.sh
 echo "export MANGO_BENCHER_REPO=$MANGO_BENCHER_REPO" >> exec-start-build-dependency-download.sh
 echo "export MANGO_BENCHER_BRANCH=$MANGO_BENCHER_BRANCH" >> exec-start-build-dependency-download.sh
 echo "export MANGO_CONFIGURE_REPO=$MANGO_CONFIGURE_REPO" >> exec-start-build-dependency-download.sh

--- a/main.sh
+++ b/main.sh
@@ -83,6 +83,7 @@ do
     else
         ret_pre_build=$(ssh -i id_ed25519_dos_test -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" sol@$sship 'bash -s' < exec-start-build-dependency-download.sh)
     fi
+    let client_num=$client_num+1
 done
 
 
@@ -90,7 +91,7 @@ echo ----- stage: run dos test ---
 client_num=1
 for sship in "${instance_ip[@]}"
 do
-    ret_pre_build=$(ssh -i id_ed25519_dos_test -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" sol@$sship 'bash -s' < exec-start-dos-test-$client_num.sh)
+    ret_run_dos=$(ssh -i id_ed25519_dos_test -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" sol@$sship 'bash -s' < exec-start-dos-test-$client_num.sh)
     let client_num=$client_num+1
     if [[ $client_num -gt ${#accounts[@]} ]];then
         client_num=1

--- a/start-build-dependency.sh
+++ b/start-build-dependency.sh
@@ -70,6 +70,7 @@ if  [[ "$BUILD_MANGO_BENCHER" == "true" ]];then
 	# cp from BUILD_DEPENDENCY_BENCHER_DIR to HOME
 	cp $BUILD_DEPENDENCY_BENCHER_DIR/target/release/mango-simulation $HOME
 	chmod +x $HOME/mango-simulation
+	upload_file $HOME/mango-simulation
 else
 	# download from bucket
 	cd $HOME
@@ -134,5 +135,3 @@ download_file dos-metrics-env.sh
 [[ ! -f "$HOME/dos-metrics-env.sh" ]]&&echo no dos-metrics-env.sh file && exit 1
 download_file dos-report-env.sh
 [[ ! -f "$HOME/dos-report-env.sh" ]]&&echo no dos-report-env.sh file && exit 1
-
-upload_file $BUILD_DEPENDENCY_BENCHER_DIR/target/release/mango-simulation

--- a/start-build-dependency.sh
+++ b/start-build-dependency.sh
@@ -28,6 +28,7 @@ echo ID_FILE: $ID_FILE >> env.output
 echo CHANNEL: $CHANNEL >> env.output
 echo RUST_VER: $RUST_VER >> env.output
 
+
 ## Download key files from gsutil
 download_file() {
 	for retry in 0 1
@@ -126,6 +127,9 @@ do
 done
 
 cd $HOME 
+download_file configure-metrics.sh
+[[ ! -f "$HOME/configure-metrics.sh" ]]&&echo no configure-metrics.sh file && exit 1
+chmod +x configure-metrics.sh
 download_file dos-metrics-env.sh
 [[ ! -f "$HOME/dos-metrics-env.sh" ]]&&echo no dos-metrics-env.sh file && exit 1
 download_file dos-report-env.sh

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -49,12 +49,8 @@ download_file() {
 }
 
 ## Prepare Metrics Env
-cd /home/sol/
-download_file configure-metrics.sh
-if [[ ! -f "configure-metrics.sh" ]];then
-	echo "NO configure-metrics.sh found" && exit 1
-fi
-chmod +x configure-metrics.sh
+cd $HOME
+
 ret_config_metric=$(exec ./configure-metrics.sh || true )
 echo ret_config_metric=$ret_config_metric
 


### PR DESCRIPTION
This PR fix mango-simulator double building issue.
This PR also moved download configure-metrics.sh from start-dos-test.sh to start-build-dependency.sh.